### PR TITLE
doc: update the trans api url documentation

### DIFF
--- a/TimeLog.API.Documentation/wwwroot/Source/TimeLog.TLP.API.XML
+++ b/TimeLog.API.Documentation/wwwroot/Source/TimeLog.TLP.API.XML
@@ -5120,7 +5120,7 @@
             Exposes methods needed to handle organizational data through the API (released March 2015) 
             </summary>
             <remarks>
-            https://app[x].timelog.com/[account name]/WebServices/Organisation/V1_6/OrganisationServiceSecure.svc
+            https://app[x].timelog.com/[account name]/WebServices/Organisation/V1_8/OrganisationServiceSecure.svc
             </remarks>
         </member>
         <member name="M:TimeLog.TLP.API.Organisation.V1_8.OrganisationService.#ctor(System.Boolean)">


### PR DESCRIPTION
Just to update on the documentation on api.timelog.com. When I checked this morning it was confusing to use it because we are at V1.8 but on the documentation the url shows `V1_6`