### PR TITLE
#25734856049 docs: improve reporting API getting started docs

### DIFF
--- a/TimeLog.API.Documentation/Views/Reporting/GettingStarted.cshtml
+++ b/TimeLog.API.Documentation/Views/Reporting/GettingStarted.cshtml
@@ -27,7 +27,7 @@
         You should see a URL with a similar pattern as above, in the section <strong>Your TImeLog API URL</strong>.
     </p>
     <p>
-        https://app[X].timelog.com/[account name]/service.asmx
+	    https://app[X].timelog.com/[account name]/service.asmx
     </p>
     <h3>2. Get the API credentials</h3>
     <p>
@@ -41,15 +41,21 @@
     </p>
     <p>Few things to note when setting up/retrieving your API credentials:</p>
     <ul>
-        <li>
-            If you see that the API ID and password are set to <code>0</code>, this means no login details have been set up yet for the API.
-        </li>
-        <li>
-            If you see other values (anything that is not <code>0</code>), API login details are already set and may be in use by other systems or tools.
-        </li>
+	    <li>
+		    <strong>API ID:</strong> This serves as your API username. It is a string that can contain both letters and numbers (for example, <code>apiUser123</code>).
+	    </li>
+	    <li>
+		    <strong>Password:</strong> The password used to authenticate API access.
+	    </li>
+	    <li>
+		    If you see that the API ID and password are set to <code>0</code>, this means no login details have been set up yet for the API.
+	    </li>
+	    <li>
+		    If you see other values (anything that is not <code>0</code>), API login details are already set and may be in use by other systems or tools.
+	    </li>
     </ul>
     <p>
-        <strong>Important:</strong> If you need to add or change the API login details while the values are not <code>0</code>, please ask your system administrator for help. Changing these details could affect other apps or automated processes that rely on them.
+	    <strong>Important:</strong> If you need to add or change the API login details while the values are not <code>0</code>, please ask your system administrator for help. Changing these details could affect other apps or automated processes that rely on them.
     </p>
     <h3>3. Test the credentials</h3>
     <p>

--- a/TimeLog.API.Documentation/Views/Reporting/GettingStarted.cshtml
+++ b/TimeLog.API.Documentation/Views/Reporting/GettingStarted.cshtml
@@ -39,6 +39,18 @@
         Take note of the Reporting API Site Code and store it. Enter the special Reporting API credentials to use
         for the API requests. 
     </p>
+    <p>Few things to note when setting up/retrieving your API credentials:</p>
+    <ul>
+        <li>
+            If you see that the API ID and password are set to <code>0</code>, this means no login details have been set up yet for the API.
+        </li>
+        <li>
+            If you see other values (anything that is not <code>0</code>), API login details are already set and may be in use by other systems or tools.
+        </li>
+    </ul>
+    <p>
+        <strong>Important:</strong> If you need to add or change the API login details while the values are not <code>0</code>, please ask your system administrator for help. Changing these details could affect other apps or automated processes that rely on them.
+    </p>
     <h3>3. Test the credentials</h3>
     <p>
         You should test your URL and credentials in the browser by navigating to the Reporting API endpoint


### PR DESCRIPTION
To improve the Reporting API documentation to include info on default credentials:
<img width="1203" height="540" alt="image" src="https://github.com/user-attachments/assets/922ec2d0-9473-4479-9323-506f90bfaadf" />