### PR TITLE
#KTLO-701 Docs: add documentation on new GETALL expense type API

### DIFF
--- a/TimeLog.API.Documentation/wwwroot/Source/TimeLog.REST.API.json
+++ b/TimeLog.API.Documentation/wwwroot/Source/TimeLog.REST.API.json
@@ -3996,6 +3996,76 @@
         ]
       }
     },
+    "/v{version}/expense-type/all/list": {
+      "get": {
+        "tags": [
+          "ExpenseType"
+        ],
+        "summary": "Get a list of expense type by status (all, inactive, active)",
+        "operationId": "ExpenseType_GetAll",
+        "consumes": [],
+        "produces": [
+          "application/json",
+          "text/json",
+          "application/problem+json"
+        ],
+        "parameters": [
+          {
+            "name": "legalEntityId",
+            "in": "query",
+            "description": "legal entity",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "description": "An enum of ActiveStatus, can be all(-1), inactive(0) or active(1)",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "enum": [
+              0,
+              1,
+              -1
+            ]
+          },
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "type": "string",
+            "default": "1"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A list of expense type",
+            "schema": {
+              "$ref": "#/definitions/TimeLog.TLP.Web.WebApi.V1.Expenses.Models.ExpenseType.ExpenseTypeExtendedApiReadModel"
+            }
+          },
+          "500": {
+            "description": "Request to GetAll has failed",
+            "schema": {
+              "$ref": "#/definitions/TimeLog.TLP.Web.Infrastructure.WebApi.Common.ResponseError"
+            }
+          },
+          "401": {
+            "description": "Invalid authentication token"
+          }
+        },
+        "security": [
+          {
+            "oauth2": [
+              ""
+            ]
+          }
+        ]
+      }
+    },
     "/v{version}/external-systems": {
       "get": {
         "tags": [


### PR DESCRIPTION
Include documentation on new REST API for expense type. API has been released to production. only requires documentation update.

Specs link: https://linear.app/timelog/issue/KTLO-697/extend-expense-type-v1-rest-api-to-include-legal-entity-in-response