### PR TITLE
#KTLO1052: Add new fields for update approval manager and update user roles/license types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.3] - 09-03-2026
+
+### Added
+
+- Added new fields for license type and role IDs on user create/update endpoints.
+- Added approval manager through user update endpoint.
+
 ## [1.0.2] - 26-02-2026
 
 ### Removed
@@ -68,6 +75,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Update below when *actual* new versions appear.
 -->
 
-[unreleased]: https://github.com/TimeLog/TimeLogApiSdk/branchCompare?baseVersion=GTv1.0.1&targetVersion=GBmaster&_a=commits
+[unreleased]: https://github.com/TimeLog/TimeLogApiSdk/branchCompare?baseVersion=GTv1.0.2&targetVersion=GBmaster&_a=commits
+[1.0.2]: https://github.com/TimeLog/TimeLogApiSdk/branchCompare?baseVersion=GTv1.0.1&targetVersion=GTv1.0.2&_a=commits
 [1.0.1]: https://github.com/TimeLog/TimeLogApiSdk/branchCompare?baseVersion=GTv1.0.0&targetVersion=GTv1.0.1&_a=commits
 [1.0.0]: https://github.com/TimeLog/TimeLogApiSdk/releases/tag/v1.0.0

--- a/TimeLog.API.Documentation/wwwroot/Source/TimeLog.REST.API.json
+++ b/TimeLog.API.Documentation/wwwroot/Source/TimeLog.REST.API.json
@@ -13647,7 +13647,7 @@
           "description": "Gets or sets legal entity id.",
           "type": "integer"
         },
-		    "Email": {
+        "Email": {
           "description": "Gets or sets email.",
           "type": "string"
         }
@@ -21515,6 +21515,33 @@
         "LastName": {
           "description": "Gets or sets the last name.",
           "type": "string"
+        },
+        "ApprovalManagerInitials": {
+          "description": "Gets or sets the approval manager initials.",
+          "type": "string"
+        },
+        "ApprovalManagerStartDate": {
+          "format": "date-time",
+          "description": "Gets or sets the effective start date for the approval manager.",
+          "type": "string"
+        },
+        "UserLicenseType": {
+          "format": "int32",
+          "description": "Gets or sets the user license type.\r\nSupported types are: Standard = 2, Limited = 7, and TimeExpense = 8.\r\nLimited (7) and TimeExpense (8) are only available if the customer subscription supports it.\r\nIf not provided, the existing license type will be preserved.",
+          "enum": [
+            2,
+            7,
+            8
+          ],
+          "type": "integer"
+        },
+        "UserRoleIDs": {
+          "description": "Gets or sets the active roles on the user.\r\nOnly applicable for Standard license type.\r\nIf not provided or empty, the existing roles will be preserved.\r\nIf provided with values, the specified roles will be added to the existing roles on the user, and UserLicenseType must be explicitly set to Standard (2).\r\nThis is required even if the user is already a Standard user, to confirm the license type before role changes.",
+          "type": "array",
+          "items": {
+            "format": "int32",
+            "type": "integer"
+          }
         }
       }
     },
@@ -21602,6 +21629,16 @@
         "SalaryGroupID": {
           "format": "int32",
           "description": "Gets or sets the salary group id.",
+          "type": "integer"
+        },
+        "UserLicenseType": {
+          "format": "int32",
+          "description": "Gets or sets the user license type.\r\nSupported types are: Standard = 2, Limited = 7, and TimeExpense = 8.\r\nLimited (7) and TimeExpense (8) are only available if the customer subscription supports it.\r\nDefault is Standard (2).",
+          "enum": [
+            2,
+            7,
+            8
+          ],
           "type": "integer"
         },
         "UserRoleIDs": {


### PR DESCRIPTION
- Added new fields for license type and role IDs on user create/update endpoints.
- Added approval manager through user update endpoint.

Dev: @gls-timelogger 